### PR TITLE
MIRACLデータセットを使用した評価機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cache
 chroma_db
 report.json
 .specstory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "datasets>=3.5.1",
     "faiss-cpu>=1.11.0",
     "fpdf>=1.7.2",
     "langchain>=0.3.24",

--- a/scripts/eval_miracl/calc_recall.py
+++ b/scripts/eval_miracl/calc_recall.py
@@ -1,0 +1,98 @@
+import os
+import pickle
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+from langchain_openai import OpenAIEmbeddings
+from tqdm import tqdm
+
+# 設定
+CACHE_DIR = Path("cache")
+EMBEDDING_CACHE = CACHE_DIR / "embeddings.pkl"
+TOP_K = 1000
+
+def batch_get_embeddings(texts: List[str], cache_key: str) -> np.ndarray:
+    """テキストのリストの埋め込みを取得（キャッシュ機能付き）"""
+    cache_path = EMBEDDING_CACHE.parent / f"embeddings_{cache_key}.pkl"
+    
+    if cache_path.exists():
+        print(f"埋め込みをキャッシュから読み込み中: {cache_key}")
+        with open(cache_path, "rb") as f:
+            return pickle.load(f)
+    
+    print(f"埋め込みを計算中: {cache_key}")
+    embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+    embeddings_array = np.array(embeddings.embed_documents(texts))
+    
+    # キャッシュに保存
+    cache_path.parent.mkdir(exist_ok=True)
+    with open(cache_path, "wb") as f:
+        pickle.dump(embeddings_array, f)
+    
+    return embeddings_array
+
+def compute_recall_at_k(
+    query_embeddings: np.ndarray,
+    corpus_embeddings: np.ndarray,
+    positive_indices: List[List[int]],
+    k: int = 100
+) -> float:
+    """Recall@Kを計算"""
+    # コサイン類似度を計算
+    similarities = query_embeddings @ corpus_embeddings.T
+    
+    # 各クエリについて上位k件を取得
+    top_k_indices = np.argsort(-similarities, axis=1)[:, :k]
+    
+    # Recall@Kを計算
+    total_recall = 0
+    for i, (top_indices, pos_indices) in enumerate(zip(top_k_indices, positive_indices)):
+        # 正解文書が上位k件に含まれている数を計算
+        hits = sum(1 for pos_idx in pos_indices if pos_idx in top_indices)
+        recall = hits / len(pos_indices)
+        total_recall += recall
+    
+    return total_recall / len(query_embeddings)
+
+def main():
+    # データセットの読み込み
+    print("データセットを読み込み中...")
+    with open(CACHE_DIR / "sample_queries_100.pkl", "rb") as f:
+        queries = pickle.load(f)
+    with open(CACHE_DIR / "sample_corpus_10000.pkl", "rb") as f:
+        corpus = pickle.load(f)
+    
+    # クエリと文書のテキストを抽出
+    query_texts = [item["query"] for item in queries]
+    corpus_texts = [item["text"] for item in corpus]
+    
+    # 正解文書のインデックスを取得
+    positive_indices = []
+    corpus_docids = [item["docid"] for item in corpus]
+    for query in queries:
+        pos_docids = [p["docid"] for p in query["positive_passages"]]
+        pos_indices = [
+            i for i, docid in enumerate(corpus_docids)
+            if docid in pos_docids
+        ]
+        if not pos_indices:
+            print(f"警告: クエリ '{query['query'][:50]}...' の正解文書が見つかりません")
+        positive_indices.append(pos_indices)
+    
+    # 埋め込みを取得
+    query_embeddings = batch_get_embeddings(query_texts, "queries")
+    corpus_embeddings = batch_get_embeddings(corpus_texts, "corpus")
+    
+    # Recall@100を計算
+    recall = compute_recall_at_k(
+        query_embeddings, 
+        corpus_embeddings, 
+        positive_indices,
+        k=TOP_K
+    )
+    
+    print(f"\nRecall@{TOP_K}: {recall:.3f}")
+
+if __name__ == "__main__":
+    main() 

--- a/scripts/eval_miracl/create_sample.py
+++ b/scripts/eval_miracl/create_sample.py
@@ -1,0 +1,102 @@
+import os
+import pickle
+import random
+from pathlib import Path
+from typing import Set, Tuple
+
+import datasets
+
+# 保存用のディレクトリを作成
+CACHE_DIR = Path("cache")
+CACHE_DIR.mkdir(exist_ok=True)
+
+def get_positive_docids(ds) -> Set[str]:
+    """データセットから正解文書のdocidを取得"""
+    docids = set()
+    for item in ds:
+        for passage in item["positive_passages"]:
+            docids.add(passage["docid"])  # "#" 以降を除去
+    return docids
+
+def load_or_create_datasets(corpus_size=10000, query_size=100) -> Tuple[datasets.Dataset, datasets.Dataset]:
+    corpus_path = CACHE_DIR / f"sample_corpus_{corpus_size}.pkl"
+    query_path = CACHE_DIR / f"sample_queries_{query_size}.pkl"
+    
+    # キャッシュされたデータセットがある場合はそれを読み込む
+    if corpus_path.exists() and query_path.exists():
+        print("キャッシュされたデータセットを読み込みます...")
+        with open(corpus_path, "rb") as f:
+            sample_corpus = pickle.load(f)
+        with open(query_path, "rb") as f:
+            sample_ds = pickle.load(f)
+    else:
+        print("データセットをダウンロードします...")
+        # クエリデータセットを取得
+        full_ds = datasets.load_dataset(
+            "miracl/miracl", 
+            "ja", 
+            token=os.environ["HF_ACCESS_TOKEN"], 
+            split="dev"
+        )
+        sample_ds = full_ds.select(range(query_size))
+        
+        # 正解文書のdocidを取得
+        print("正解文書のdocidを取得します...")
+        positive_docids = get_positive_docids(sample_ds)
+        pos_size = len(positive_docids)
+        
+        print("コーパスをロードします...")
+        full_corpus = datasets.load_dataset("miracl/miracl-corpus", "ja", split="train")
+        
+        # 初期サブセットを作成（corpus_size + 正解文書数*10）
+        print("初期サブセットを作成します...")
+        initial_subset_size = corpus_size + pos_size * 10
+        initial_subset = full_corpus.select(random.sample(range(len(full_corpus)), initial_subset_size))
+        
+        # 初期サブセットから非正解文書のみを抽出
+        print("非正解文書を抽出します...")
+        neg_docs = [doc for doc in initial_subset if doc["docid"] not in positive_docids]
+        
+        # 必要な数の負例をサンプリング
+        print("負例をサンプリングします...")
+        neg_size = corpus_size - pos_size
+        assert len(neg_docs) >= neg_size, f"十分な負例が得られませんでした。初期サブセットサイズを大きくしてください。(必要数: {neg_size}, 取得数: {len(neg_docs)})"
+        
+        sampled_neg_docs = random.sample(neg_docs, neg_size)
+        
+        # 最終的なコーパスを作成
+        print("最終的なコーパスを作成します...")
+        # 正解文書をfilterで取得
+        pos_docs = full_corpus.filter(lambda x: x["docid"] in positive_docids)
+        sample_corpus = datasets.Dataset.from_list(list(pos_docs) + sampled_neg_docs)
+        
+        # データセットを保存
+        print("データセットをキャッシュに保存します...")
+        with open(corpus_path, "wb") as f:
+            pickle.dump(sample_corpus, f)
+        with open(query_path, "wb") as f:
+            pickle.dump(sample_ds, f)
+    
+    return sample_corpus, sample_ds
+
+def main():
+    # データセットを取得
+    sample_corpus, sample_ds = load_or_create_datasets()
+    
+    # 正解文書の数を確認
+    positive_docids = get_positive_docids(sample_ds)
+    positive_docs = [doc for doc in sample_corpus if doc["docid"] in positive_docids]
+    
+    print(f"コーパスサイズ: {len(sample_corpus)}")
+    print(f"クエリ数: {len(sample_ds)}")
+    print(f"正解文書数: {len(positive_docs)}")
+    print(f"負例文書数: {len(sample_corpus) - len(positive_docs)}")
+    
+    # サンプルデータの内容確認
+    print("\nサンプルクエリ:")
+    print(sample_ds[0]["query"])
+    print("\n対応する正解文書:")
+    print(sample_ds[0]["positive_passages"][0]["text"][:100])
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_miracl/eval_llm.py
+++ b/scripts/eval_miracl/eval_llm.py
@@ -1,0 +1,450 @@
+import json
+import pickle
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Literal
+
+import numpy as np
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+from tqdm import tqdm
+
+
+class SearchEvaluation(BaseModel):
+    """検索結果の評価"""
+    explanation: str = Field(description="評価の理由")
+    label: Literal["OK", "Partial", "NG"] = Field(description="検索結果の評価ラベル")
+
+# プロンプトテンプレート
+EVAL_PROMPT_TEMPLATE = ChatPromptTemplate(
+    [
+        ("system", "あなたは検索結果の評価を行うアシスタントです。質問に対する検索結果が、その質問に答えるための十分な情報を含んでいるかを評価してください。"),
+        ("user", """質問: {query}
+
+検索結果:
+{search_results}
+
+上記の検索結果は、質問に答えるための十分な情報を含んでいますか？
+評価の理由を出力してから以下の3つのラベルのいずれかで回答してください：
+- OK: 質問に完全に答えるための情報が含まれている
+- Partial: 質問に部分的に答えるための情報が含まれている
+- NG: 質問に答えるための情報が含まれていない"""),
+    ]
+)
+
+# 設定
+CACHE_DIR = Path("cache")
+TOP_K = 10  # 各クエリについて評価する検索結果の数
+NUM_SAMPLES = -1  # 評価するクエリの数
+BATCH_SIZE = 10  # バッチサイズ
+
+def get_search_results(
+    query_embeddings: np.ndarray,
+    corpus_embeddings: np.ndarray,
+    corpus: list[dict],
+    k: int = 10
+) -> list[list[dict]]:
+    """各クエリの検索結果を取得
+
+    Args:
+        query_embeddings: クエリの埋め込みベクトル。shape=(クエリ数, 埋め込み次元)
+        corpus_embeddings: コーパスの埋め込みベクトル。shape=(コーパス数, 埋め込み次元)
+        corpus: コーパスのリスト。各要素は以下のキーを含む辞書:
+            - docid: 文書ID
+            - text: 文書のテキスト
+            - title: 文書のタイトル（オプション）
+        k: 各クエリについて取得する検索結果の数
+
+    Returns:
+        各クエリの検索結果のリスト。shape=(クエリ数, k)
+        各検索結果は元のコーパスの辞書と同じ形式
+    """
+    # コサイン類似度を計算
+    similarities = query_embeddings @ corpus_embeddings.T
+    
+    # 各クエリについて上位k件を取得
+    results = []
+    for i in range(len(query_embeddings)):
+        top_k_indices = np.argsort(-similarities[i])[:k]
+        results.append([corpus[idx] for idx in top_k_indices])
+    
+    return results
+
+def create_positive_sample(
+    query: dict,
+    sorted_indices: np.ndarray,
+    pos_indices: list[int],
+    corpus: list[dict],
+    k: int
+) -> dict:
+    """正解を含む検索結果を作成
+
+    Args:
+        query: 質問。以下のキーを含む辞書:
+            - query: 質問文
+            - positive_passages: 正解文書のリスト
+        sorted_indices: 類似度でソートされた文書のインデックス
+        pos_indices: 正解文書のインデックスのリスト
+        corpus: コーパスのリスト
+        k: 検索結果に含める文書数
+
+    Returns:
+        評価用のサンプル。以下のキーを含む辞書:
+            - query: 質問文
+            - search_results: 検索結果の文書リスト
+            - has_positive: 正解文書を含むかどうか
+            - positive_passages: 正解文書リスト
+    """
+    top_k_indices = sorted_indices[:k].tolist()
+    # sorted_indicesの順序で正解文書を取得
+    missing_positives = [idx for idx in sorted_indices if idx in pos_indices and idx not in top_k_indices]
+    
+    if missing_positives:
+        # 含まれていない正解を、正解でない文書と入れ替え
+        # 後ろから順に処理することで、順序を維持
+        for pos_idx in reversed(missing_positives):
+            # 後ろから順に正解でない文書を探す
+            for idx in reversed(top_k_indices):
+                if idx not in pos_indices:
+                    # 正解でない文書を見つけたら、それを正解と入れ替え
+                    replace_idx = top_k_indices.index(idx)
+                    top_k_indices[replace_idx] = pos_idx
+                    break
+    
+    results = [corpus[idx] for idx in top_k_indices]
+    return {
+        "query": query["query"],
+        "search_results": results,
+        "has_positive": True,
+        "positive_passages": query["positive_passages"]
+    }
+
+def create_negative_sample(
+    query: dict,
+    sorted_indices: np.ndarray,
+    pos_indices: list[int],
+    corpus: list[dict],
+    k: int
+) -> dict:
+    """正解を含まない検索結果を作成
+
+    Args:
+        query: 質問。以下のキーを含む辞書:
+            - query: 質問文
+            - positive_passages: 正解文書のリスト
+        sorted_indices: 類似度でソートされた文書のインデックス
+        pos_indices: 正解文書のインデックスのリスト
+        corpus: コーパスのリスト
+        k: 検索結果に含める文書数
+
+    Returns:
+        評価用のサンプル。以下のキーを含む辞書:
+            - query: 質問文
+            - search_results: 検索結果の文書リスト
+            - has_positive: 正解文書を含むかどうか
+            - positive_passages: 正解文書リスト
+    """
+    # sorted_indicesから正解でないものをk個取得
+    neg_indices = []
+    for idx in sorted_indices:
+        if idx not in pos_indices:
+            neg_indices.append(idx)
+            if len(neg_indices) == k:
+                break
+    
+    results = [corpus[idx] for idx in neg_indices]
+    return {
+        "query": query["query"],
+        "search_results": results,
+        "has_positive": False,
+        "positive_passages": query["positive_passages"]
+    }
+
+def create_positive_negative_samples(
+    query_embeddings: np.ndarray,
+    corpus_embeddings: np.ndarray,
+    corpus: list[dict],
+    queries: list[dict],
+    positive_indices: list[list[int]],
+    k: int = 10
+) -> list[dict]:
+    """各クエリに対して正解を含む/含まない検索結果を作成
+
+    Args:
+        query_embeddings: クエリの埋め込みベクトル。shape=(クエリ数, 埋め込み次元)
+        corpus_embeddings: コーパスの埋め込みベクトル。shape=(コーパス数, 埋め込み次元)
+        corpus: コーパスのリスト。各要素は以下のキーを含む辞書:
+            - docid: 文書ID
+            - text: 文書のテキスト
+            - title: 文書のタイトル（オプション）
+        queries: 質問のリスト。各質問は以下のキーを含む辞書:
+            - query: 質問文
+            - positive_passages: 正解文書のリスト
+        positive_indices: 各質問の正解文書のインデックスのリスト
+        k: 各検索結果に含める文書数
+
+    Returns:
+        評価用のサンプルのリスト。各サンプルは以下のキーを含む辞書:
+            - query: 質問文
+            - search_results: 検索結果の文書リスト
+            - has_positive: 正解文書を含むかどうか
+            - positive_passages: 正解文書リスト
+    """
+    samples = []
+    
+    # コサイン類似度を計算
+    similarities = query_embeddings @ corpus_embeddings.T
+    
+    for i, (query, pos_indices) in enumerate(zip(queries, positive_indices)):
+        # 類似度でソートした全インデックス
+        sorted_indices = np.argsort(-similarities[i])
+        
+        # 正解を含む検索結果を作成
+        if pos_indices:  # 正解文書が存在する場合
+            samples.append(create_positive_sample(query, sorted_indices, pos_indices, corpus, k))
+        
+        # 正解を含まない検索結果を作成
+        samples.append(create_negative_sample(query, sorted_indices, pos_indices, corpus, k))
+    
+    return samples
+
+def evaluate_with_llm(samples: list[dict]) -> list[dict[str, Any]]:
+    """LLMで評価を実行
+
+    Args:
+        samples: 評価用のサンプルのリスト。各サンプルは以下のキーを含む辞書:
+            - query: 質問文
+            - search_results: 検索結果の文書リスト
+            - has_positive: 正解文書を含むかどうか
+            - positive_passages: 正解文書リスト
+
+    Returns:
+        評価結果のリスト。各結果は以下のキーを含む辞書:
+            - query: 質問文
+            - has_positive: 正解文書を含むかどうか
+            - llm_label: LLMによる評価ラベル（OK/Partial/NG）
+            - explanation: 評価の理由
+    """
+    # LLMの設定
+    model = ChatOpenAI(model="gpt-4o", temperature=0).with_structured_output(SearchEvaluation)
+    chain = EVAL_PROMPT_TEMPLATE | model
+    
+    # 入力データの準備
+    inputs = []
+    for sample in samples:
+        search_results_text = ""
+        for i, result in enumerate(sample["search_results"], 1):
+            title = result.get("title", "")
+            title_text = f"【{title}】" if title else ""
+            search_results_text += f"\n{i}. {title_text}{result['text']}..."
+        
+        inputs.append({
+            "query": sample["query"],
+            "search_results": search_results_text
+        })
+    
+    # バッチ処理で評価を実行
+    with tqdm(total=len(samples), desc="LLMで評価中") as pbar:
+        eval_results = []
+        for i in range(0, len(inputs), BATCH_SIZE):
+            batch = inputs[i:i + BATCH_SIZE]
+            batch_results = chain.batch(batch)
+            eval_results.extend(batch_results)
+            pbar.update(len(batch))
+    
+    # 結果の整形
+    results = []
+    for sample, eval_result in zip(samples, eval_results):
+        results.append({
+            "query": sample["query"],
+            "has_positive": sample["has_positive"],
+            "llm_label": eval_result.label,
+            "explanation": eval_result.explanation
+        })
+    
+    return results
+
+def calculate_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """評価指標を計算
+
+    Args:
+        results: evaluate_with_llmの戻り値。各結果は以下のキーを含む辞書:
+            - has_positive: 正解文書を含むかどうか
+            - llm_label: LLMによる評価ラベル（OK/Partial/NG）
+
+    Returns:
+        評価指標を含む辞書:
+            - positive_cases: 正解を含むケースの数
+            - negative_cases: 正解を含まないケースの数
+            - positive_rates: 正解を含むケースのラベル分布
+            - negative_rates: 正解を含まないケースのラベル分布
+    """
+    # 正解を含むケースと含まないケースを分ける
+    positive_cases = [r for r in results if r["has_positive"]]
+    negative_cases = [r for r in results if not r["has_positive"]]
+    
+    # 各ケースでのラベル分布を計算
+    def calc_label_rates(cases: list[dict[str, Any]]) -> dict[str, float]:
+        """各ラベルの出現率を計算
+
+        Args:
+            cases: 評価結果のリスト。各要素は以下のキーを含む辞書:
+                - llm_label: LLMによる評価ラベル（OK/Partial/NG）
+
+        Returns:
+            各ラベルの出現率を含む辞書:
+                - OK: OKラベルの割合
+                - Partial: Partialラベルの割合
+                - NG: NGラベルの割合
+        """
+        total = len(cases)
+        if total == 0:
+            return {"OK": 0.0, "Partial": 0.0, "NG": 0.0}
+        
+        return {
+            "OK": sum(1 for r in cases if r["llm_label"] == "OK") / total,
+            "Partial": sum(1 for r in cases if r["llm_label"] == "Partial") / total,
+            "NG": sum(1 for r in cases if r["llm_label"] == "NG") / total
+        }
+    
+    positive_rates = calc_label_rates(positive_cases)
+    negative_rates = calc_label_rates(negative_cases)
+    
+    return {
+        "positive_cases": len(positive_cases),
+        "negative_cases": len(negative_cases),
+        "positive_rates": positive_rates,
+        "negative_rates": negative_rates
+    }
+
+def save_evaluation_results(
+    results: List[dict],
+    metrics: Dict[str, Any],
+    samples: List[dict],
+    output_dir: Path
+) -> None:
+    """評価結果をJSONファイルとして保存
+
+    Args:
+        results: evaluate_with_llmの結果
+        metrics: calculate_metricsの結果
+        samples: 評価に使用したサンプル
+        output_dir: 出力先ディレクトリ
+    """
+    # ドキュメントの辞書を作成
+    documents = {}
+    for sample in samples:
+        for doc in sample["search_results"]:
+            if doc["docid"] not in documents:
+                documents[doc["docid"]] = doc["text"]
+    
+    # 詳細な評価結果を作成
+    details = []
+    for result, sample in zip(results, samples):
+        details.append({
+            "query": result["query"],
+            "has_positive": result["has_positive"],
+            "llm_label": result["llm_label"],
+            "explanation": result["explanation"],
+            "search_result_ids": [doc["docid"] for doc in sample["search_results"]],
+            "positive_passage_ids": [doc["docid"] for doc in sample["positive_passages"]]
+        })
+    
+    # 評価結果全体を作成
+    evaluation_results = {
+        "summary": {
+            "total_samples": len(results),
+            "positive_cases": metrics["positive_cases"],
+            "positive_rates": metrics["positive_rates"],
+            "negative_cases": metrics["negative_cases"],
+            "negative_rates": metrics["negative_rates"]
+        },
+        "details": details,
+        "documents": documents
+    }
+    
+    # 出力先ディレクトリを作成
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # JSONファイルとして保存
+    output_file = output_dir / "evaluation_results.json"
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(evaluation_results, f, ensure_ascii=False, indent=2)
+    
+    print(f"\n評価結果を保存しました: {output_file}")
+
+def main():
+    # キャッシュされた埋め込みを読み込み
+    print("埋め込みを読み込み中...")
+    with open(CACHE_DIR / "embeddings_queries.pkl", "rb") as f:
+        query_embeddings = pickle.load(f)
+    with open(CACHE_DIR / "embeddings_corpus.pkl", "rb") as f:
+        corpus_embeddings = pickle.load(f)
+    
+    # データセットを読み込み
+    print("データセットを読み込み中...")
+    with open(CACHE_DIR / "sample_queries_100.pkl", "rb") as f:
+        queries = pickle.load(f)
+    with open(CACHE_DIR / "sample_corpus_10000.pkl", "rb") as f:
+        corpus = list(pickle.load(f))
+    
+    # 評価するクエリをランダムに選択
+    if NUM_SAMPLES > 0 and NUM_SAMPLES < len(queries):
+        print(f"ランダムに{NUM_SAMPLES}個のクエリを選択します...")
+        selected_indices = random.sample(range(len(queries)), NUM_SAMPLES)
+        queries = [queries[i] for i in selected_indices]
+        query_embeddings = query_embeddings[selected_indices]
+    
+    all_docids = [doc["docid"] for doc in corpus]
+    
+    # 正解文書のインデックスを取得
+    positive_indices = []
+    for query in queries:
+        pos_docids = [p["docid"] for p in query["positive_passages"]]
+        pos_indices = [
+            i for i, docid in enumerate(all_docids)
+            if docid in pos_docids
+        ]
+        positive_indices.append(pos_indices)
+    
+    # 評価用サンプルを作成
+    print("評価用サンプルを作成中...")
+    samples = create_positive_negative_samples(
+        query_embeddings,
+        corpus_embeddings,
+        corpus,
+        queries,
+        positive_indices,
+        k=TOP_K
+    )
+    
+    # LLMで評価
+    evaluation_results = evaluate_with_llm(samples)
+    
+    # 評価指標を計算
+    metrics = calculate_metrics(evaluation_results)
+    
+    # 評価結果を表示
+    print("\n=== 評価結果 ===")
+    print(f"評価サンプル数: {len(evaluation_results)}")
+    print(f"正解を含むケース: {metrics['positive_cases']}")
+    print("- ラベル分布:")
+    for label, rate in metrics["positive_rates"].items():
+        print(f"  - {label}: {rate:.3f}")
+    
+    print(f"\n正解を含まないケース: {metrics['negative_cases']}")
+    print("- ラベル分布:")
+    for label, rate in metrics["negative_rates"].items():
+        print(f"  - {label}: {rate:.3f}")
+    
+    # 評価結果をファイルに保存
+    save_evaluation_results(
+        evaluation_results,
+        metrics,
+        samples,
+        output_dir=CACHE_DIR / "results"
+    )
+
+if __name__ == "__main__":
+    main() 

--- a/src/dbcoverageeval/judge.py
+++ b/src/dbcoverageeval/judge.py
@@ -34,7 +34,7 @@ def judge_search_result(question: str, documents: list[Document]) -> JudgeResult
     
     chain = JUDGE_PROMPT_TEMPLATE | model
     
-    result = chain.invoke({"question": question, "docs_text": "\n".join([doc.page_content for doc in documents])})
+    result = chain.invoke({"question": question, "docs_text": "\n\n".join([doc.page_content for doc in documents])})
     
     detailed_result = DetailedJudgeResult(question=question, judge=result.judge, reason=result.reason, search_results=documents)
     

--- a/uv.lock
+++ b/uv.lock
@@ -438,10 +438,36 @@ wheels = [
 ]
 
 [[package]]
+name = "datasets"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/af/8c1d10daf37383c32ab0a7461eaa4d5c7a3c47808fe5a8563744de002df7/datasets-3.5.1.tar.gz", hash = "sha256:f835b45dbbd7065c1191734b6f7c8d96fdf8c5751feaa5aa52b2a0dc43eea58f", size = 568915, upload_time = "2025-04-28T14:01:42.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/f5/668b3444a2f487b0052b908af631fe39eeb2bdb2359d9bbc2c3b80b71119/datasets-3.5.1-py3-none-any.whl", hash = "sha256:4074dda8dd6e9ece242b1580a8ef3928777d59ae1db144d911229e443a093cbb", size = 491436, upload_time = "2025-04-28T14:01:40.953Z" },
+]
+
+[[package]]
 name = "dbcoverageeval"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "datasets" },
     { name = "faiss-cpu" },
     { name = "fpdf" },
     { name = "langchain" },
@@ -460,6 +486,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "datasets", specifier = ">=3.5.1" },
     { name = "faiss-cpu", specifier = ">=1.11.0" },
     { name = "fpdf", specifier = ">=1.7.2" },
     { name = "langchain", specifier = ">=0.3.24" },
@@ -486,6 +513,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload_time = "2025-01-27T10:46:25.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload_time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload_time = "2024-01-27T23:42:16.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload_time = "2024-01-27T23:42:14.239Z" },
 ]
 
 [[package]]
@@ -650,11 +686,16 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2025.3.2"
+version = "2025.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/d8/8425e6ba5fcec61a1d16e41b1b71d2bf9344f1fe48012c2b48b9620feae5/fsspec-2025.3.2.tar.gz", hash = "sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6", size = 299281, upload_time = "2025-03-31T15:27:08.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/f4/5721faf47b8c499e776bc34c6a8fc17efdf7fdef0b00f398128bc5dcb4ac/fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972", size = 298491, upload_time = "2025-03-07T21:47:56.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/4b/e0cfc1a6f17e990f3e64b7d941ddc4acdc7b19d6edd51abf495f32b1a9e4/fsspec-2025.3.2-py3-none-any.whl", hash = "sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711", size = 194435, upload_time = "2025-03-31T15:27:07.028Z" },
+    { url = "https://files.pythonhosted.org/packages/56/53/eb690efa8513166adef3e0669afd31e95ffde69fb3c52ec2ac7223ed6018/fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3", size = 193615, upload_time = "2025-03-07T21:47:54.809Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -1291,6 +1332,22 @@ wheels = [
 ]
 
 [[package]]
+name = "multiprocess"
+version = "0.70.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload_time = "2024-01-28T18:52:34.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/7ec7fddc92e50714ea3745631f79bd9c96424cb2702632521028e57d3a36/multiprocess-0.70.16-py310-none-any.whl", hash = "sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02", size = 134824, upload_time = "2024-01-28T18:52:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/50/15/b56e50e8debaf439f44befec5b2af11db85f6e0f344c3113ae0be0593a91/multiprocess-0.70.16-py311-none-any.whl", hash = "sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a", size = 143519, upload_time = "2024-01-28T18:52:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload_time = "2024-01-28T18:52:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload_time = "2024-01-28T18:52:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload_time = "2024-01-28T18:52:31.981Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1823,6 +1880,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/b5/bade14ae31ba871a139aa45e7a8183d869efe87c34a4850c87b936963261/protobuf-5.29.4-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:aec4962f9ea93c431d5714ed1be1c93f13e1a8618e70035ba2b0564d9e633f2e", size = 319574, upload_time = "2025-03-19T21:23:14.531Z" },
     { url = "https://files.pythonhosted.org/packages/46/88/b01ed2291aae68b708f7d334288ad5fb3e7aa769a9c309c91a0d55cb91b0/protobuf-5.29.4-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:d7d3f7d1d5a66ed4942d4fefb12ac4b14a29028b209d4bfb25c68ae172059922", size = 319672, upload_time = "2025-03-19T21:23:15.839Z" },
     { url = "https://files.pythonhosted.org/packages/12/fb/a586e0c973c95502e054ac5f81f88394f24ccc7982dac19c515acd9e2c93/protobuf-5.29.4-py3-none-any.whl", hash = "sha256:3fde11b505e1597f71b875ef2fc52062b6a9740e5f7c8997ce878b6009145862", size = 172551, upload_time = "2025-03-19T21:23:22.682Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "20.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ee/a7810cb9f3d6e9238e61d312076a9859bf3668fd21c69744de9532383912/pyarrow-20.0.0.tar.gz", hash = "sha256:febc4a913592573c8d5805091a6c2b5064c8bd6e002131f01061797d91c783c1", size = 1125187, upload_time = "2025-04-27T12:34:23.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/a2/b7930824181ceadd0c63c1042d01fa4ef63eee233934826a7a2a9af6e463/pyarrow-20.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:24ca380585444cb2a31324c546a9a56abbe87e26069189e14bdba19c86c049f0", size = 30856035, upload_time = "2025-04-27T12:28:40.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/18/c765770227d7f5bdfa8a69f64b49194352325c66a5c3bb5e332dfd5867d9/pyarrow-20.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:95b330059ddfdc591a3225f2d272123be26c8fa76e8c9ee1a77aad507361cfdb", size = 32309552, upload_time = "2025-04-27T12:28:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fb/dfb2dfdd3e488bb14f822d7335653092dde150cffc2da97de6e7500681f9/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f0fb1041267e9968c6d0d2ce3ff92e3928b243e2b6d11eeb84d9ac547308232", size = 41334704, upload_time = "2025-04-27T12:28:55.064Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0d/08a95878d38808051a953e887332d4a76bc06c6ee04351918ee1155407eb/pyarrow-20.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8ff87cc837601532cc8242d2f7e09b4e02404de1b797aee747dd4ba4bd6313f", size = 42399836, upload_time = "2025-04-27T12:29:02.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cd/efa271234dfe38f0271561086eedcad7bc0f2ddd1efba423916ff0883684/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7a3a5dcf54286e6141d5114522cf31dd67a9e7c9133d150799f30ee302a7a1ab", size = 40711789, upload_time = "2025-04-27T12:29:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1f/7f02009bc7fc8955c391defee5348f510e589a020e4b40ca05edcb847854/pyarrow-20.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a6ad3e7758ecf559900261a4df985662df54fb7fdb55e8e3b3aa99b23d526b62", size = 42301124, upload_time = "2025-04-27T12:29:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/92/692c562be4504c262089e86757a9048739fe1acb4024f92d39615e7bab3f/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6bb830757103a6cb300a04610e08d9636f0cd223d32f388418ea893a3e655f1c", size = 42916060, upload_time = "2025-04-27T12:29:24.253Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ec/9f5c7e7c828d8e0a3c7ef50ee62eca38a7de2fa6eb1b8fa43685c9414fef/pyarrow-20.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:96e37f0766ecb4514a899d9a3554fadda770fb57ddf42b63d80f14bc20aa7db3", size = 44547640, upload_time = "2025-04-27T12:29:32.782Z" },
+    { url = "https://files.pythonhosted.org/packages/54/96/46613131b4727f10fd2ffa6d0d6f02efcc09a0e7374eff3b5771548aa95b/pyarrow-20.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3346babb516f4b6fd790da99b98bed9708e3f02e734c84971faccb20736848dc", size = 25781491, upload_time = "2025-04-27T12:29:38.464Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d6/0c10e0d54f6c13eb464ee9b67a68b8c71bcf2f67760ef5b6fbcddd2ab05f/pyarrow-20.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:75a51a5b0eef32727a247707d4755322cb970be7e935172b6a3a9f9ae98404ba", size = 30815067, upload_time = "2025-04-27T12:29:44.384Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e2/04e9874abe4094a06fd8b0cbb0f1312d8dd7d707f144c2ec1e5e8f452ffa/pyarrow-20.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:211d5e84cecc640c7a3ab900f930aaff5cd2702177e0d562d426fb7c4f737781", size = 32297128, upload_time = "2025-04-27T12:29:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/31/fd/c565e5dcc906a3b471a83273039cb75cb79aad4a2d4a12f76cc5ae90a4b8/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ba3cf4182828be7a896cbd232aa8dd6a31bd1f9e32776cc3796c012855e1199", size = 41334890, upload_time = "2025-04-27T12:29:59.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a9/3bdd799e2c9b20c1ea6dc6fa8e83f29480a97711cf806e823f808c2316ac/pyarrow-20.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c3a01f313ffe27ac4126f4c2e5ea0f36a5fc6ab51f8726cf41fee4b256680bd", size = 42421775, upload_time = "2025-04-27T12:30:06.875Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f7/da98ccd86354c332f593218101ae56568d5dcedb460e342000bd89c49cc1/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a2791f69ad72addd33510fec7bb14ee06c2a448e06b649e264c094c5b5f7ce28", size = 40687231, upload_time = "2025-04-27T12:30:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1b/2168d6050e52ff1e6cefc61d600723870bf569cbf41d13db939c8cf97a16/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4250e28a22302ce8692d3a0e8ec9d9dde54ec00d237cff4dfa9c1fbf79e472a8", size = 42295639, upload_time = "2025-04-27T12:30:21.949Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/2d976c0c7158fd25591c8ca55aee026e6d5745a021915a1835578707feb3/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:89e030dc58fc760e4010148e6ff164d2f44441490280ef1e97a542375e41058e", size = 42908549, upload_time = "2025-04-27T12:30:29.551Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a9/dfb999c2fc6911201dcbf348247f9cc382a8990f9ab45c12eabfd7243a38/pyarrow-20.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6102b4864d77102dbbb72965618e204e550135a940c2534711d5ffa787df2a5a", size = 44557216, upload_time = "2025-04-27T12:30:36.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/9adee63dfa3911be2382fb4d92e4b2e7d82610f9d9f668493bebaa2af50f/pyarrow-20.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:96d6a0a37d9c98be08f5ed6a10831d88d52cac7b13f5287f1e0f625a0de8062b", size = 25660496, upload_time = "2025-04-27T12:30:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/aa/daa413b81446d20d4dad2944110dcf4cf4f4179ef7f685dd5a6d7570dc8e/pyarrow-20.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a15532e77b94c61efadde86d10957950392999503b3616b2ffcef7621a002893", size = 30798501, upload_time = "2025-04-27T12:30:48.351Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/75/2303d1caa410925de902d32ac215dc80a7ce7dd8dfe95358c165f2adf107/pyarrow-20.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:dd43f58037443af715f34f1322c782ec463a3c8a94a85fdb2d987ceb5658e061", size = 32277895, upload_time = "2025-04-27T12:30:55.238Z" },
+    { url = "https://files.pythonhosted.org/packages/92/41/fe18c7c0b38b20811b73d1bdd54b1fccba0dab0e51d2048878042d84afa8/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0d288143a8585806e3cc7c39566407aab646fb9ece164609dac1cfff45f6ae", size = 41327322, upload_time = "2025-04-27T12:31:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ab/7dbf3d11db67c72dbf36ae63dcbc9f30b866c153b3a22ef728523943eee6/pyarrow-20.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6953f0114f8d6f3d905d98e987d0924dabce59c3cda380bdfaa25a6201563b4", size = 42411441, upload_time = "2025-04-27T12:31:15.675Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c3/0c7da7b6dac863af75b64e2f827e4742161128c350bfe7955b426484e226/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:991f85b48a8a5e839b2128590ce07611fae48a904cae6cab1f089c5955b57eb5", size = 40677027, upload_time = "2025-04-27T12:31:24.631Z" },
+    { url = "https://files.pythonhosted.org/packages/be/27/43a47fa0ff9053ab5203bb3faeec435d43c0d8bfa40179bfd076cdbd4e1c/pyarrow-20.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:97c8dc984ed09cb07d618d57d8d4b67a5100a30c3818c2fb0b04599f0da2de7b", size = 42281473, upload_time = "2025-04-27T12:31:31.311Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0b/d56c63b078876da81bbb9ba695a596eabee9b085555ed12bf6eb3b7cab0e/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9b71daf534f4745818f96c214dbc1e6124d7daf059167330b610fc69b6f3d3e3", size = 42893897, upload_time = "2025-04-27T12:31:39.406Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ac/7d4bd020ba9145f354012838692d48300c1b8fe5634bfda886abcada67ed/pyarrow-20.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b88758f9303fa5a83d6c90e176714b2fd3852e776fc2d7e42a22dd6c2fb368", size = 44543847, upload_time = "2025-04-27T12:31:45.997Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/07/290f4abf9ca702c5df7b47739c1b2c83588641ddfa2cc75e34a301d42e55/pyarrow-20.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:30b3051b7975801c1e1d387e17c588d8ab05ced9b1e14eec57915f79869b5031", size = 25653219, upload_time = "2025-04-27T12:31:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/720bb17704b10bd69dde086e1400b8eefb8f58df3f8ac9cff6c425bf57f1/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:ca151afa4f9b7bc45bcc791eb9a89e90a9eb2772767d0b1e5389609c7d03db63", size = 30853957, upload_time = "2025-04-27T12:31:59.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/72/0d5f875efc31baef742ba55a00a25213a19ea64d7176e0fe001c5d8b6e9a/pyarrow-20.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:4680f01ecd86e0dd63e39eb5cd59ef9ff24a9d166db328679e36c108dc993d4c", size = 32247972, upload_time = "2025-04-27T12:32:05.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/bc/e48b4fa544d2eea72f7844180eb77f83f2030b84c8dad860f199f94307ed/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f4c8534e2ff059765647aa69b75d6543f9fef59e2cd4c6d18015192565d2b70", size = 41256434, upload_time = "2025-04-27T12:32:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/01/974043a29874aa2cf4f87fb07fd108828fc7362300265a2a64a94965e35b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e1f8a47f4b4ae4c69c4d702cfbdfe4d41e18e5c7ef6f1bb1c50918c1e81c57b", size = 42353648, upload_time = "2025-04-27T12:32:20.766Z" },
+    { url = "https://files.pythonhosted.org/packages/68/95/cc0d3634cde9ca69b0e51cbe830d8915ea32dda2157560dda27ff3b3337b/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a1f60dc14658efaa927f8214734f6a01a806d7690be4b3232ba526836d216122", size = 40619853, upload_time = "2025-04-27T12:32:28.1Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c2/3ad40e07e96a3e74e7ed7cc8285aadfa84eb848a798c98ec0ad009eb6bcc/pyarrow-20.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:204a846dca751428991346976b914d6d2a82ae5b8316a6ed99789ebf976551e6", size = 42241743, upload_time = "2025-04-27T12:32:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/cb/65fa110b483339add6a9bc7b6373614166b14e20375d4daa73483755f830/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f3b117b922af5e4c6b9a9115825726cac7d8b1421c37c2b5e24fbacc8930612c", size = 42839441, upload_time = "2025-04-27T12:32:46.64Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7b/f30b1954589243207d7a0fbc9997401044bf9a033eec78f6cb50da3f304a/pyarrow-20.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e724a3fd23ae5b9c010e7be857f4405ed5e679db5c93e66204db1a69f733936a", size = 44503279, upload_time = "2025-04-27T12:32:56.503Z" },
+    { url = "https://files.pythonhosted.org/packages/37/40/ad395740cd641869a13bcf60851296c89624662575621968dcfafabaa7f6/pyarrow-20.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:82f1ee5133bd8f49d31be1299dc07f585136679666b502540db854968576faf9", size = 25944982, upload_time = "2025-04-27T12:33:04.72Z" },
 ]
 
 [[package]]
@@ -2634,6 +2735,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986, upload_time = "2025-01-14T10:35:00.498Z" },
     { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750, upload_time = "2025-01-14T10:35:03.378Z" },
     { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload_time = "2025-01-14T10:35:44.018Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/5e/d6e5258d69df8b4ed8c83b6664f2b47d30d2dec551a29ad72a6c69eafd31/xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f", size = 84241, upload_time = "2024-08-17T09:20:38.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/c7/afed0f131fbda960ff15eee7f304fa0eeb2d58770fade99897984852ef23/xxhash-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:02c2e816896dc6f85922ced60097bcf6f008dedfc5073dcba32f9c8dd786f3c1", size = 31969, upload_time = "2024-08-17T09:18:00.852Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/0c/7c3bc6d87e5235672fcc2fb42fd5ad79fe1033925f71bf549ee068c7d1ca/xxhash-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6027dcd885e21581e46d3c7f682cfb2b870942feeed58a21c29583512c3f09f8", size = 30800, upload_time = "2024-08-17T09:18:01.863Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9e/01067981d98069eec1c20201f8c145367698e9056f8bc295346e4ea32dd1/xxhash-3.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1308fa542bbdbf2fa85e9e66b1077eea3a88bef38ee8a06270b4298a7a62a166", size = 221566, upload_time = "2024-08-17T09:18:03.461Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/09/d4996de4059c3ce5342b6e1e6a77c9d6c91acce31f6ed979891872dd162b/xxhash-3.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c28b2fdcee797e1c1961cd3bcd3d545cab22ad202c846235197935e1df2f8ef7", size = 201214, upload_time = "2024-08-17T09:18:05.616Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f5/6d2dc9f8d55a7ce0f5e7bfef916e67536f01b85d32a9fbf137d4cadbee38/xxhash-3.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:924361811732ddad75ff23e90efd9ccfda4f664132feecb90895bade6a1b4623", size = 429433, upload_time = "2024-08-17T09:18:06.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/72/9256303f10e41ab004799a4aa74b80b3c5977d6383ae4550548b24bd1971/xxhash-3.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89997aa1c4b6a5b1e5b588979d1da048a3c6f15e55c11d117a56b75c84531f5a", size = 194822, upload_time = "2024-08-17T09:18:08.331Z" },
+    { url = "https://files.pythonhosted.org/packages/34/92/1a3a29acd08248a34b0e6a94f4e0ed9b8379a4ff471f1668e4dce7bdbaa8/xxhash-3.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:685c4f4e8c59837de103344eb1c8a3851f670309eb5c361f746805c5471b8c88", size = 208538, upload_time = "2024-08-17T09:18:10.332Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ad/7fa1a109663366de42f724a1cdb8e796a260dbac45047bce153bc1e18abf/xxhash-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbd2ecfbfee70bc1a4acb7461fa6af7748ec2ab08ac0fa298f281c51518f982c", size = 216953, upload_time = "2024-08-17T09:18:11.707Z" },
+    { url = "https://files.pythonhosted.org/packages/35/02/137300e24203bf2b2a49b48ce898ecce6fd01789c0fcd9c686c0a002d129/xxhash-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:25b5a51dc3dfb20a10833c8eee25903fd2e14059e9afcd329c9da20609a307b2", size = 203594, upload_time = "2024-08-17T09:18:13.799Z" },
+    { url = "https://files.pythonhosted.org/packages/23/03/aeceb273933d7eee248c4322b98b8e971f06cc3880e5f7602c94e5578af5/xxhash-3.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a8fb786fb754ef6ff8c120cb96629fb518f8eb5a61a16aac3a979a9dbd40a084", size = 210971, upload_time = "2024-08-17T09:18:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/64/ed82ec09489474cbb35c716b189ddc1521d8b3de12b1b5ab41ce7f70253c/xxhash-3.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a905ad00ad1e1c34fe4e9d7c1d949ab09c6fa90c919860c1534ff479f40fd12d", size = 415050, upload_time = "2024-08-17T09:18:17.142Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/6db4c02dcb488ad4e03bc86d70506c3d40a384ee73c9b5c93338eb1f3c23/xxhash-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:963be41bcd49f53af6d795f65c0da9b4cc518c0dd9c47145c98f61cb464f4839", size = 192216, upload_time = "2024-08-17T09:18:18.779Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6d/db4abec29e7a567455344433d095fdb39c97db6955bb4a2c432e486b4d28/xxhash-3.5.0-cp311-cp311-win32.whl", hash = "sha256:109b436096d0a2dd039c355fa3414160ec4d843dfecc64a14077332a00aeb7da", size = 30120, upload_time = "2024-08-17T09:18:20.009Z" },
+    { url = "https://files.pythonhosted.org/packages/52/1c/fa3b61c0cf03e1da4767213672efe186b1dfa4fc901a4a694fb184a513d1/xxhash-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:b702f806693201ad6c0a05ddbbe4c8f359626d0b3305f766077d51388a6bac58", size = 30003, upload_time = "2024-08-17T09:18:21.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/9e6fc572acf6e1cc7ccb01973c213f895cb8668a9d4c2b58a99350da14b7/xxhash-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:c4dcb4120d0cc3cc448624147dba64e9021b278c63e34a38789b688fd0da9bf3", size = 26777, upload_time = "2024-08-17T09:18:22.809Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0e/1bfce2502c57d7e2e787600b31c83535af83746885aa1a5f153d8c8059d6/xxhash-3.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:14470ace8bd3b5d51318782cd94e6f94431974f16cb3b8dc15d52f3b69df8e00", size = 31969, upload_time = "2024-08-17T09:18:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/8ca450d6fe5b71ce521b4e5db69622383d039e2b253e9b2f24f93265b52c/xxhash-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59aa1203de1cb96dbeab595ded0ad0c0056bb2245ae11fac11c0ceea861382b9", size = 30787, upload_time = "2024-08-17T09:18:25.318Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/de7c89bc6ef63d750159086a6ada6416cc4349eab23f76ab870407178b93/xxhash-3.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08424f6648526076e28fae6ea2806c0a7d504b9ef05ae61d196d571e5c879c84", size = 220959, upload_time = "2024-08-17T09:18:26.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/51258d3e8a8545ff26468c977101964c14d56a8a37f5835bc0082426c672/xxhash-3.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a1ff00674879725b194695e17f23d3248998b843eb5e933007ca743310f793", size = 200006, upload_time = "2024-08-17T09:18:27.905Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0a/96973bd325412feccf23cf3680fd2246aebf4b789122f938d5557c54a6b2/xxhash-3.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f2c61bee5844d41c3eb015ac652a0229e901074951ae48581d58bfb2ba01be", size = 428326, upload_time = "2024-08-17T09:18:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a7/81dba5010f7e733de88af9555725146fc133be97ce36533867f4c7e75066/xxhash-3.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d32a592cac88d18cc09a89172e1c32d7f2a6e516c3dfde1b9adb90ab5df54a6", size = 194380, upload_time = "2024-08-17T09:18:30.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7d/f29006ab398a173f4501c0e4977ba288f1c621d878ec217b4ff516810c04/xxhash-3.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70dabf941dede727cca579e8c205e61121afc9b28516752fd65724be1355cc90", size = 207934, upload_time = "2024-08-17T09:18:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6e/6e88b8f24612510e73d4d70d9b0c7dff62a2e78451b9f0d042a5462c8d03/xxhash-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e5d0ddaca65ecca9c10dcf01730165fd858533d0be84c75c327487c37a906a27", size = 216301, upload_time = "2024-08-17T09:18:33.474Z" },
+    { url = "https://files.pythonhosted.org/packages/af/51/7862f4fa4b75a25c3b4163c8a873f070532fe5f2d3f9b3fc869c8337a398/xxhash-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e5b5e16c5a480fe5f59f56c30abdeba09ffd75da8d13f6b9b6fd224d0b4d0a2", size = 203351, upload_time = "2024-08-17T09:18:34.889Z" },
+    { url = "https://files.pythonhosted.org/packages/22/61/8d6a40f288f791cf79ed5bb113159abf0c81d6efb86e734334f698eb4c59/xxhash-3.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149b7914451eb154b3dfaa721315117ea1dac2cc55a01bfbd4df7c68c5dd683d", size = 210294, upload_time = "2024-08-17T09:18:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/17/02/215c4698955762d45a8158117190261b2dbefe9ae7e5b906768c09d8bc74/xxhash-3.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:eade977f5c96c677035ff39c56ac74d851b1cca7d607ab3d8f23c6b859379cab", size = 414674, upload_time = "2024-08-17T09:18:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/b7a8db8a3237cff3d535261325d95de509f6a8ae439a5a7a4ffcff478189/xxhash-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa9f547bd98f5553d03160967866a71056a60960be00356a15ecc44efb40ba8e", size = 192022, upload_time = "2024-08-17T09:18:40.138Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e3/dd76659b2811b3fd06892a8beb850e1996b63e9235af5a86ea348f053e9e/xxhash-3.5.0-cp312-cp312-win32.whl", hash = "sha256:f7b58d1fd3551b8c80a971199543379be1cee3d0d409e1f6d8b01c1a2eebf1f8", size = 30170, upload_time = "2024-08-17T09:18:42.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6b/1c443fe6cfeb4ad1dcf231cdec96eb94fb43d6498b4469ed8b51f8b59a37/xxhash-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa0cafd3a2af231b4e113fba24a65d7922af91aeb23774a8b78228e6cd785e3e", size = 30040, upload_time = "2024-08-17T09:18:43.699Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/eb/04405305f290173acc0350eba6d2f1a794b57925df0398861a20fbafa415/xxhash-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:586886c7e89cb9828bcd8a5686b12e161368e0064d040e225e72607b43858ba2", size = 26796, upload_time = "2024-08-17T09:18:45.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/e4b3ad92d249be5c83fa72916c9091b0965cb0faeff05d9a0a3870ae6bff/xxhash-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37889a0d13b0b7d739cfc128b1c902f04e32de17b33d74b637ad42f1c55101f6", size = 31795, upload_time = "2024-08-17T09:18:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/b3627a0aebfbfa4c12a41e22af3742cf08c8ea84f5cc3367b5de2d039cce/xxhash-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:97a662338797c660178e682f3bc180277b9569a59abfb5925e8620fba00b9fc5", size = 30792, upload_time = "2024-08-17T09:18:47.862Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cc/762312960691da989c7cd0545cb120ba2a4148741c6ba458aa723c00a3f8/xxhash-3.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f85e0108d51092bdda90672476c7d909c04ada6923c14ff9d913c4f7dc8a3bc", size = 220950, upload_time = "2024-08-17T09:18:49.06Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e9/cc266f1042c3c13750e86a535496b58beb12bf8c50a915c336136f6168dc/xxhash-3.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd2fd827b0ba763ac919440042302315c564fdb797294d86e8cdd4578e3bc7f3", size = 199980, upload_time = "2024-08-17T09:18:50.445Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/85/a836cd0dc5cc20376de26b346858d0ac9656f8f730998ca4324921a010b9/xxhash-3.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82085c2abec437abebf457c1d12fccb30cc8b3774a0814872511f0f0562c768c", size = 428324, upload_time = "2024-08-17T09:18:51.988Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0e/15c243775342ce840b9ba34aceace06a1148fa1630cd8ca269e3223987f5/xxhash-3.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07fda5de378626e502b42b311b049848c2ef38784d0d67b6f30bb5008642f8eb", size = 194370, upload_time = "2024-08-17T09:18:54.164Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a1/b028bb02636dfdc190da01951d0703b3d904301ed0ef6094d948983bef0e/xxhash-3.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c279f0d2b34ef15f922b77966640ade58b4ccdfef1c4d94b20f2a364617a493f", size = 207911, upload_time = "2024-08-17T09:18:55.509Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d5/73c73b03fc0ac73dacf069fdf6036c9abad82de0a47549e9912c955ab449/xxhash-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:89e66ceed67b213dec5a773e2f7a9e8c58f64daeb38c7859d8815d2c89f39ad7", size = 216352, upload_time = "2024-08-17T09:18:57.073Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2a/5043dba5ddbe35b4fe6ea0a111280ad9c3d4ba477dd0f2d1fe1129bda9d0/xxhash-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bcd51708a633410737111e998ceb3b45d3dbc98c0931f743d9bb0a209033a326", size = 203410, upload_time = "2024-08-17T09:18:58.54Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b2/9a8ded888b7b190aed75b484eb5c853ddd48aa2896e7b59bbfbce442f0a1/xxhash-3.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ff2c0a34eae7df88c868be53a8dd56fbdf592109e21d4bfa092a27b0bf4a7bf", size = 210322, upload_time = "2024-08-17T09:18:59.943Z" },
+    { url = "https://files.pythonhosted.org/packages/98/62/440083fafbc917bf3e4b67c2ade621920dd905517e85631c10aac955c1d2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e28503dccc7d32e0b9817aa0cbfc1f45f563b2c995b7a66c4c8a0d232e840c7", size = 414725, upload_time = "2024-08-17T09:19:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/db/009206f7076ad60a517e016bb0058381d96a007ce3f79fa91d3010f49cc2/xxhash-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a6c50017518329ed65a9e4829154626f008916d36295b6a3ba336e2458824c8c", size = 192070, upload_time = "2024-08-17T09:19:03.007Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/6d/c61e0668943a034abc3a569cdc5aeae37d686d9da7e39cf2ed621d533e36/xxhash-3.5.0-cp313-cp313-win32.whl", hash = "sha256:53a068fe70301ec30d868ece566ac90d873e3bb059cf83c32e76012c889b8637", size = 30172, upload_time = "2024-08-17T09:19:04.355Z" },
+    { url = "https://files.pythonhosted.org/packages/96/14/8416dce965f35e3d24722cdf79361ae154fa23e2ab730e5323aa98d7919e/xxhash-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:80babcc30e7a1a484eab952d76a4f4673ff601f54d5142c26826502740e70b43", size = 30041, upload_time = "2024-08-17T09:19:05.435Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ee/518b72faa2073f5aa8e3262408d284892cb79cf2754ba0c3a5870645ef73/xxhash-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:4811336f1ce11cac89dcbd18f3a25c527c16311709a89313c3acaf771def2d4b", size = 26801, upload_time = "2024-08-17T09:19:06.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# MIRACLデータセットを使用した評価機能の追加

## 変更内容
- MIRACLデータセットを使用した評価スクリプトの追加
- 検索結果の評価ロジックの改善（文書間の区切りを改善）
- 必要なパッケージの依存関係追加（datasets, pyarrow, xxhash）
